### PR TITLE
[BUG-2345] - Investigate servers melting down due to possible memory leak

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,16 +1,17 @@
 import DS from 'ember-data';
 import ENV from 'super-cool-app/config/environment';
-import { computed } from '@ember/object';
-import { readOnly } from '@ember/object/computed';
+import { get } from '@ember/object';
 
 export default DS.JSONAPIAdapter.extend({
   ENV,
-  authToken: readOnly('ENV.API.token'),
+  get authToken() {
+    return ENV.API.token;
+  },
 
-  headers: computed(function() {
+  get headers() {
     return {
       Accept: 'application/json',
-      Authorization: `Bearer ${this.authToken}`
+      Authorization: `Bearer ${get(this, 'authToken')}`
     };
-  })
+  }
 });


### PR DESCRIPTION
[[BUG-2345] - Investigate servers melting down due to possible memory leak](http://tinyurl.com/4m6eoes)

## Change Description
Web servers have been crashing lately due to a suspected memory leak.  The team tracked down the issue to a computed `headers` property (which is valid per the [API](https://www.example.com) docs).  In our case, having the `headers` as a computed property badly leaks the `container`, causing a massive FastBoot memory leak that never gets cleared up without forcing the servers to reboot every hour.  The solution, after hours of investigation, was simply to convert the `computed` property into a `get`ter.

## Changes 
 - Convert `headers` property on base adapter from `computed` to `get`ter

## Envrionments
Any, although testing the fix will require running the app server locally

## Links
http://www.example.com/us/test-page

## Testing Steps
- Ensure you have pulled this branch down
- Follow the setup instructions in the ReadMe for [configuring the server to run benchmarks in a browser](https://tinyurl.com/y2tedfeh)
- In the same document, review the steps for capturing memory heap snapshots
- Use Apache Bench to issue 10 requests to the affected URL (ex: `ab -c 1 -n 10 http://www.example.com/us/test-page`)
- Review the memory snapshots and confirm that memory is not leaking (see [presentation](https://www.dropbox.com/s/jbdn54fc32n7qlf/FastFlood.pptx?dl=0) for more information)

|Before|After|
|---|---|
|![before frowning face](https://i.imgur.com/hBIZ6H4.png)|![after happy face](https://i.imgur.com/v9IrCZ6.png)|
